### PR TITLE
Quit driver instances when called as top level modules

### DIFF
--- a/join-orgs-beta.js
+++ b/join-orgs-beta.js
@@ -19,6 +19,10 @@ require('./lib/sharedNemo').then(function(nemo) {
       nemo.view.login.loginButton().click(),
       nemo.view.nav.usernameWaitVisible(),
       nemo.view.org.bannerInfoTextEquals('Organizations are here!')
-    ]).then(t.ok).catch(t.error).then(t.end);
+    ]).then(function() {
+      if (!module.parent) {
+        nemo.driver.quit();
+      }
+    }).catch(t.error).then(t.end);
   });
 });

--- a/joinwhoshiring.js
+++ b/joinwhoshiring.js
@@ -31,4 +31,12 @@ require('./lib/sharedNemo').then(function(nemo) {
       }).then(t.pass)
     ]).catch(t.error).then(t.end);
   })
+
+  tap.test('close driver', function(t) {
+    if (!module.parent) {
+      nemo.driver.quit();
+    }
+    t.end();
+  });
+
 }).catch(tap.error).then(tap.end);

--- a/logout.js
+++ b/logout.js
@@ -10,7 +10,11 @@ tap.test("Log out a user", function(t) {
       nemo.driver.get(urlOf('/')),
       nemo.view.nav.logoutLink().click(),
       nemo.view.nav.loginLinkWaitVisible()
-    ]).then(t.ok);
+    ]).then(t.ok).then(function() {
+      if (!module.parent) {
+        nemo.driver.quit();
+      }
+    });
   }).catch(function(error) {
     t.error(error);
     t.bailout();

--- a/onsite-trial.js
+++ b/onsite-trial.js
@@ -22,6 +22,10 @@ require('./lib/sharedNemo').then(function(nemo) {
       nemo.view.onsite.submitAgreement().click(),
       nemo.view.onsite.h2WaitVisible(),
       nemo.view.onsite.h2TextEquals('time to check your email').then(pass(t, 'confirmation found'))
-    ]).then(t.ok).catch(t.error).then(t.end);
+    ]).then(function() {
+      if (!module.parent) {
+        return nemo.driver.quit();
+      }
+    }).catch(t.error).then(t.end);
   });
 });

--- a/signup-private-modules.js
+++ b/signup-private-modules.js
@@ -18,6 +18,10 @@ require('./lib/sharedNemo').then(function(nemo) {
       nemo.view.billing.cardCVC().sendKeys("513"),
       nemo.view.billing.submit().click(),
       nemo.view.billing.noticeWaitVisible()
-    ]).then(t.ok).catch(t.error).then(t.end);
+    ]).then(function() {
+      if (!module.parent) {
+        return nemo.driver.quit();
+      }
+    }).catch(t.error).then(t.end);
   });
 });

--- a/signup.js
+++ b/signup.js
@@ -19,6 +19,10 @@ tap.test("Sign up a user", function(t) {
       t.ok(text, 'username is shown');
       nemo.state.username = text;
       t.pass("signed up " + text);
+    }).then(function() {
+      if (!module.parent) {
+        return nemo.driver.quit();
+      }
     });
   }).catch(function(error) {
     t.error(error);


### PR DESCRIPTION
This allows tests to be run as subtests for complex tests, but still
cleaning up when run separately.
